### PR TITLE
feat: use compression when downloading casks

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -3,7 +3,7 @@
 downloaded=$(mktemp -p .)
 exit=0
 
-curl --compressed -s -o $downloaded https://formulae.brew.sh/api/cask.json
+curl --compressed --silent --output $downloaded https://formulae.brew.sh/api/cask.json
 
 if [ "$?" = 0 ]; then
   mv -f $downloaded casks.json


### PR DESCRIPTION
By default curl uses none. Passing `--compressed` automatically adds
`Accept-Encoding` with compression algorithms supported by current
version of curl, and handles decompressing response.

Brew casks JSON is about 12Mb right now, and compressed with gzip it's
only 1.6Mb. This doesn't really affect download speed (current github
action runs complete that step in less than a second), but still
probably no need to pass extra data when we can avoid that.

My rather unscientific measurements:

```
❯ cat curl-format.txt
     time_namelookup:  %{time_namelookup}s\n
        time_connect:  %{time_connect}s\n
     time_appconnect:  %{time_appconnect}s\n
    time_pretransfer:  %{time_pretransfer}s\n
   time_posttransfer:  %{time_posttransfer}s\n
       time_redirect:  %{time_redirect}s\n
  time_starttransfer:  %{time_starttransfer}s\n
       size_download:  %{size_download}\n
                     ----------\n
          time_total:  %{time_total}s\n

❯ curl -w "@curl-format.txt" -o /dev/null -s https://formulae.brew.sh/api/cask.json
     time_namelookup:  0.003670s
        time_connect:  0.018523s
     time_appconnect:  0.038456s
    time_pretransfer:  0.038516s
   time_posttransfer:  0.038569s
       time_redirect:  0.000000s
  time_starttransfer:  0.051923s
       size_download:  12336523
                     ----------
          time_total:  0.764385s

❯ curl -w "@curl-format.txt" --compressed -o /dev/null -s https://formulae.brew.sh/api/cask.json
     time_namelookup:  0.003677s
        time_connect:  0.023446s
     time_appconnect:  0.043795s
    time_pretransfer:  0.043863s
   time_posttransfer:  0.043915s
       time_redirect:  0.000000s
  time_starttransfer:  0.186708s
       size_download:  1591992
                     ----------
          time_total:  0.302024s
```
